### PR TITLE
Fixes issue #2. Additional cleanup.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,6 @@ include Makefile
 include *.spec
 include *.txt
 include LICENSE
-include VERSION
 recursive-include test *.py
 recursive-include test *.yaml
+recursive-include test *.json

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ RPMNVR = "$(NAME)-$(VERSION)-$(RPMRELEASE)"
 PEP8_IGNORE = E302,E203,E261,E402
 ########################################################
 
-all: clean check pep8 pyflakes pylint tests coverage_report
+all: clean check pep8 pyflakes pylint unittest coverage_report systest
 
 check:
 	check-manifest

--- a/ServiceNowRac/snow_session.py
+++ b/ServiceNowRac/snow_session.py
@@ -46,7 +46,8 @@ import time
 import logging
 
 from requests import Session
-from requests.exceptions import RequestException, ConnectionError, HTTPError, Timeout
+from requests.exceptions import RequestException, ConnectionError, HTTPError, \
+    Timeout
 
 class MaxRetryError(RequestException):
     '''An Max Retry error occurred.'''

--- a/ServiceNowRac/snow_table.py
+++ b/ServiceNowRac/snow_table.py
@@ -74,12 +74,16 @@ class SnowTable(object):
         return self.conn.post(self.table, sysparm, data)
 
     def insert_multiple(self, data):
-        ''' Create multiple new records.
+        ''' Create multiple new records. Format of payload should model
+            { "records" : [ { ... }, { ... } ] }
         '''
-        # XXX This won't work. Need:
-        # { "records" : [ { ... }, { ... } ] }
+        if not isinstance(data, list):
+            raise TypeError('Invalid type. insert_multiple requires list of '
+                            'records.')
+
         sysparm = 'sysparm_action=insertMultiple'
-        return self.conn.post(self.table, sysparm, data)
+        records = {'records': data}
+        return self.conn.post(self.table, sysparm, records)
 
     def update(self, data, query):
         ''' Update existing records filtered by the encoded query string.

--- a/test/system/test_snow_client.py
+++ b/test/system/test_snow_client.py
@@ -31,9 +31,6 @@
 
 ''' System Tests for Client
 '''
-import sys
-import os
-sys.path.append(os.path.join(os.path.dirname(__file__), '../lib'))
 import unittest
 
 from config import CONFIG

--- a/test/system/test_snow_table.py
+++ b/test/system/test_snow_table.py
@@ -36,6 +36,8 @@ import os
 sys.path.append(os.path.join(os.path.dirname(__file__), '../lib'))
 import unittest
 
+from testlib import random_string
+
 from ServiceNowRac.snow_client import SnowClient
 from ServiceNowRac.snow_table import SnowTable
 
@@ -128,17 +130,21 @@ class TestSnowTable(unittest.TestCase):
         resp = self.table.get(sys_id)
         self.assertEquals(resp, None)
 
-    def test_07_insert_multiple(self):
-        ''' Verify 'insert_multiple' functionality
+    def test_08_insert_delete_multiple(self):
+        ''' Verify 'insert_multiple' and 'delete_multiple' functionality
         '''
-        # { "records" : [ { ... }, { ... } ] }
-        #       data = self.table.insert_multiple(data)
+        create_num = 5
+        data = []
+        for _ in range(create_num):
+            description = 'Systest Generated: %s' % random_string(5, 10)
+            data.append({'short_description': description})
 
-    def test_08_delete_multiple(self):
-        ''' Verify 'delete_multiple' functionality
-        '''
-        # data = self.table.delete_multiple('name=Arista Networks')
-        # self.assertEquals(len(data), 52)
+        resp = self.table.insert_multiple(data)
+        self.assertEquals(len(resp), create_num)
+
+        query_str = 'short_descriptionSTARTSWITHSystest Generated:'
+        resp = self.table.delete_multiple(query_str)
+        self.assertEquals(resp[0]['count'], create_num)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit/mock_defs.py
+++ b/test/unit/mock_defs.py
@@ -156,7 +156,7 @@ def snow_table_insert(url, request):
 def snow_table_insert_multiple(url, request):
     ''' Mock POST insert multiple request response
     '''
-    content_json = get_fixture_data('incident_table_insert.json')
+    content_json = get_fixture_data('incident_table_insert_multiple.json')
     return response(200, content_json, HEADERS, None, 5, request)
 
 @urlmatch(scheme='https', netloc=NETLOC, path='/incident.do', query='JSONv2',
@@ -192,5 +192,5 @@ def snow_table_delete(url, request):
 def snow_table_delete_multiple(url, request):
     ''' Mock POST delete multiple request response
     '''
-    content_json = get_fixture_data('incident_table_delete_multiple.json')
+    content_json = json.dumps({"records" : [{"count" : 5}]})
     return response(200, content_json, HEADERS, None, 5, request)

--- a/test/unit/test_snow_client.py
+++ b/test/unit/test_snow_client.py
@@ -31,9 +31,6 @@
 
 ''' Unit Tests for SnowClient
 '''
-import sys
-import os
-sys.path.append(os.path.join(os.path.dirname(__file__), '../lib'))
 import unittest
 
 from requests.exceptions import HTTPError, TooManyRedirects
@@ -44,11 +41,10 @@ from ServiceNowRac.snow_client import SnowClient
 from ServiceNowRac.snow_session import MaxRetryError
 
 from mock_defs import http_return_302, http_return_404, http_return_502, \
-                      http_timeout_error, http_connection_error, \
-                      snow_table_getkeys, snow_request_json_no_record, \
-                      snow_post_json_valid, snow_post_json_no_payload, \
-                      snow_invalid_sysparm_action, snow_invalid_insert, \
-                      snow_bad_json_return, http_too_many_redirects
+    http_timeout_error, http_connection_error, snow_table_getkeys, \
+    snow_request_json_no_record, snow_post_json_valid, \
+    snow_post_json_no_payload, snow_invalid_sysparm_action, \
+    snow_invalid_insert, snow_bad_json_return, http_too_many_redirects
 
 class TestSnowClient(unittest.TestCase):
     ''' Tests the ServiceNow Client using Mock tests
@@ -80,22 +76,22 @@ class TestSnowClient(unittest.TestCase):
         ''' Verify 'get' handing of HTTP404
         '''
         with HTTMock(http_return_404):
-            self.assertRaises(HTTPError,
-                              self.client.get, 'incident', 'sysparm_action=getKeys')
+            self.assertRaises(HTTPError, self.client.get, 'incident',
+                              'sysparm_action=getKeys')
 
     def test_03_get_502(self):
         ''' Verify 'get' handing of HTTP404
         '''
         with HTTMock(http_return_502):
-            self.assertRaises(MaxRetryError,
-                              self.client.get, 'incident', 'sysparm_action=getKeys')
+            self.assertRaises(MaxRetryError, self.client.get, 'incident',
+                              'sysparm_action=getKeys')
 
     def test_04_get_too_many_redirects(self):
         ''' Verify 'get' handing of TooManyRedirects
         '''
         with HTTMock(http_too_many_redirects):
-            self.assertRaises(TooManyRedirects,
-                              self.client.get, 'incident', 'sysparm_action=getKeys')
+            self.assertRaises(TooManyRedirects, self.client.get, 'incident',
+                              'sysparm_action=getKeys')
 
     def test_05_get_json_ret_error(self):
         ''' Verify 'get' handling of error status in json


### PR DESCRIPTION
Added support for multiInsert/multiDelete with tests. Fixes issue #2.
Also reordered make all to have ``unittest`` precede ``coverage_report`` with ``systest`` following so  system tests will not overwrite the coverage report
